### PR TITLE
small fixes

### DIFF
--- a/src/Exscript/protocols/drivers/brocade.py
+++ b/src/Exscript/protocols/drivers/brocade.py
@@ -22,10 +22,8 @@ from Exscript.protocols.drivers.driver import Driver
 _user_re     = [re.compile(r'[\r\n\r\n]Please Enter Login Name: $')]
 _password_re = [re.compile(r'[\r\n](Please Enter Password: $|Password:$)')]
 _warning     = r'(?:Warning: \d+ user\(s\) already in config mode\.)'
-_prompt      = r'[\r\n]?(telnet|SSH)@[\-\w+\.:]+(?:\([-\w]+\))?[>#]$'
-
+_prompt      = r'[\r\n]?(telnet|SSH)@[\-\w+\.:]+(?:\([\-\w]+\))?[>#]$'
 _prompt_re   = [re.compile(_warning + r'?' + _prompt)]                                                                                                                         
-# _prompt_re   = [re.compile(r'[\r\n][\-\w+\.:/]+(?:\([^\)]+\))?[>#] ?$')]
 _error_re    = [re.compile(r'%Error'),
                 re.compile(r'Invalid input', re.I),
                 re.compile(r'(?:incomplete|ambiguous) command', re.I),


### PR DESCRIPTION
Regex's like these aren't my strongest part. I don't fully understand why it passed the tests without the - instead of the - in for instance the last line of 'tests/Exscript/protocols/banners/brocade.4'
