### PR TITLE
Added Cisco ASA

### DIFF
--- a/src/Exscript/protocols/drivers/__init__.py
+++ b/src/Exscript/protocols/drivers/__init__.py
@@ -1,6 +1,7 @@
 import inspect
 from Exscript.protocols.drivers.driver import Driver
 from Exscript.protocols.drivers.aix import AIXDriver
+from Exscript.protocols.drivers.asa import ASADriver
 from Exscript.protocols.drivers.arbor_peakflow import ArborPeakflowDriver
 from Exscript.protocols.drivers.brocade import BrocadeDriver
 from Exscript.protocols.drivers.enterasys import EnterasysDriver

--- a/src/Exscript/protocols/drivers/asa.py
+++ b/src/Exscript/protocols/drivers/asa.py
@@ -28,7 +28,7 @@ _error_re    = [re.compile(r'%Error'),
                 re.compile(r'connection timed out', re.I),
                 re.compile(r'[^\r\n]+ not found', re.I)]
 
-class IOSDriver(Driver):
+class ASADriver(Driver):
     def __init__(self):
         Driver.__init__(self, 'ios')
         self.user_re     = _user_re


### PR DESCRIPTION
Added a separate driver for the Cisco ASA's.  It's the exact same as the IOS driver, except init_terminal calls 'term pager 0' instead of 'term len 0'
