### PR TITLE
Add support for Cisco Aironet WLC

### DIFF
--- a/src/Exscript/protocols/drivers/__init__.py
+++ b/src/Exscript/protocols/drivers/__init__.py
@@ -1,5 +1,6 @@
 import inspect
 from Exscript.protocols.drivers.driver import Driver
+from Exscript.protocols.drivers.aironet import AironetDriver
 from Exscript.protocols.drivers.aix import AIXDriver
 from Exscript.protocols.drivers.arbor_peakflow import ArborPeakflowDriver
 from Exscript.protocols.drivers.brocade import BrocadeDriver

--- a/src/Exscript/protocols/drivers/aironet.py
+++ b/src/Exscript/protocols/drivers/aironet.py
@@ -21,7 +21,7 @@ from Exscript.protocols.drivers.driver import Driver
 _user_re     = [re.compile(r'User:\s$', re.I)]
 _password_re = [re.compile(r'(?:[\r\n]Password: ?|last resort password:)$')]
 _tacacs_re   = re.compile(r'[\r\n]s\/key[\S ]+\r?%s' % _password_re[0].pattern)
-_prompt_re   = [re.compile(r'[\r\n].Cisco\sController.\s>\s$')]
+_prompt_re   = [re.compile(r'[\r\n].Cisco\sController.\s>$')]
 _error_re    = [re.compile(r'%Error'),
                 re.compile(r'invalid input', re.I),
                 re.compile(r'(?:incomplete|ambiguous) command', re.I),

--- a/src/Exscript/protocols/drivers/aironet.py
+++ b/src/Exscript/protocols/drivers/aironet.py
@@ -13,15 +13,15 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 """
-A driver for Cisco Aironet
+A driver for Cisco Aironet Wireless Controllers
 """
 import re
 from Exscript.protocols.drivers.driver import Driver
 
-_user_re     = [re.compile(r'User: ?$', re.I)]
+_user_re     = [re.compile(r'User:\s$', re.I)]
 _password_re = [re.compile(r'(?:[\r\n]Password: ?|last resort password:)$')]
 _tacacs_re   = re.compile(r'[\r\n]s\/key[\S ]+\r?%s' % _password_re[0].pattern)
-_prompt_re   = [re.compile(r'[\r\n]\S+?> ?$')]
+_prompt_re   = [re.compile(r'[\r\n].+?>\s$')]
 _error_re    = [re.compile(r'%Error'),
                 re.compile(r'invalid input', re.I),
                 re.compile(r'(?:incomplete|ambiguous) command', re.I),

--- a/src/Exscript/protocols/drivers/aironet.py
+++ b/src/Exscript/protocols/drivers/aironet.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2015 Mike Pennington, Samuel Abels
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+"""
+A driver for Cisco Aironet
+"""
+import re
+from Exscript.protocols.drivers.driver import Driver
+
+_user_re     = [re.compile(r'User: ?$', re.I)]
+_password_re = [re.compile(r'(?:[\r\n]Password: ?|last resort password:)$')]
+_tacacs_re   = re.compile(r'[\r\n]s\/key[\S ]+\r?%s' % _password_re[0].pattern)
+_prompt_re   = [re.compile(r'[\r\n]\S+?> ?$')]
+_error_re    = [re.compile(r'%Error'),
+                re.compile(r'invalid input', re.I),
+                re.compile(r'(?:incomplete|ambiguous) command', re.I),
+                re.compile(r'connection timed out', re.I),
+                re.compile(r'[^\r\n]+ not found', re.I)]
+
+class AironetDriver(Driver):
+    def __init__(self):
+        super(Driver, self).__init__('aironet')
+        self.user_re     = _user_re
+        self.password_re = _password_re
+        self.prompt_re   = _prompt_re
+        #self.error_re    = _error_re
+
+    def check_head_for_os(self, string):
+        if '(Cisco Controller)' in string:
+            return 60
+        if _tacacs_re.search(string):
+            return 50
+        if _user_re[0].search(string):
+            return 30
+        return 0
+
+    def init_terminal(self, conn):
+        conn.execute('config pager disable')

--- a/src/Exscript/protocols/drivers/aironet.py
+++ b/src/Exscript/protocols/drivers/aironet.py
@@ -21,7 +21,7 @@ from Exscript.protocols.drivers.driver import Driver
 _user_re     = [re.compile(r'User:\s$', re.I)]
 _password_re = [re.compile(r'(?:[\r\n]Password: ?|last resort password:)$')]
 _tacacs_re   = re.compile(r'[\r\n]s\/key[\S ]+\r?%s' % _password_re[0].pattern)
-_prompt_re   = [re.compile(r'[\r\n].+?>\s$')]
+_prompt_re   = [re.compile(r'[\r\n].Cisco\sController.\s>\s$')]
 _error_re    = [re.compile(r'%Error'),
                 re.compile(r'invalid input', re.I),
                 re.compile(r'(?:incomplete|ambiguous) command', re.I),

--- a/src/Exscript/protocols/drivers/aironet.py
+++ b/src/Exscript/protocols/drivers/aironet.py
@@ -30,7 +30,7 @@ _error_re    = [re.compile(r'%Error'),
 
 class AironetDriver(Driver):
     def __init__(self):
-        super(Driver, self).__init__('aironet')
+        Driver.__init__(self, 'aironet')
         self.user_re     = _user_re
         self.password_re = _password_re
         self.prompt_re   = _prompt_re

--- a/src/Exscript/protocols/drivers/aironet.py
+++ b/src/Exscript/protocols/drivers/aironet.py
@@ -19,8 +19,13 @@ import re
 from Exscript.protocols.drivers.driver import Driver
 
 _user_re     = [re.compile(r'User:\s$', re.I)]
-#_password_re = [re.compile(r'(?:[\r\n]Password: ?|last resort password:)$')]
+_password_re = [re.compile(r'(?:[\r\n]Password: ?|last resort password:)$')]
 _prompt_re   = [re.compile(r'[\r\n].Cisco\sController.\s>$')]
+_error_re    = [re.compile(r'%Error'),
+                re.compile(r'invalid input', re.I),
+                re.compile(r'(?:incomplete|ambiguous) command', re.I),
+                re.compile(r'connection timed out', re.I),
+                re.compile(r'[^\r\n]+ not found', re.I)]
 
 class AironetDriver(Driver):
     def __init__(self):
@@ -31,8 +36,6 @@ class AironetDriver(Driver):
     def check_head_for_os(self, string):
         if '(Cisco Controller)' in string:
             return 90
-        if _user_re[0].search(string):
-            return 30
         return 0
 
     def init_terminal(self, conn):

--- a/tests/Exscript/protocols/banners/aironet.1
+++ b/tests/Exscript/protocols/banners/aironet.1
@@ -1,0 +1,6 @@
+(Cisco Controller)
+
+User: imuseless
+Password:****
+
+(Cisco Controller) >

--- a/tests/Exscript/protocols/banners/aironet.1
+++ b/tests/Exscript/protocols/banners/aironet.1
@@ -1,6 +1,4 @@
 (Cisco Controller)
-
-User: imuseless
-Password:****
-
+User: admin
+Password:*********
 (Cisco Controller) >

--- a/tests/Exscript/protocols/banners/aironet.2
+++ b/tests/Exscript/protocols/banners/aironet.2
@@ -1,0 +1,4 @@
+(Cisco Controller)
+User: imuseless
+Password:***********
+(Cisco Controller) >


### PR DESCRIPTION
Please consider this pull request for inclusion in exscript.  Most changes were in src/Exscript/protocols/drivers/aironet.py

Test results follow...

    (py27_exscript)[mpenning@tsunami exscript]$ cd tests/Exscript
    (py27_exscript)[mpenning@tsunami Exscript]$ python protocols/OsGuesserTest.py
    testConstructor (__main__.OsGuesserTest) ... ok
    testDataReceived (__main__.OsGuesserTest) ... ok
    testGet (__main__.OsGuesserTest) ... ok
    testReset (__main__.OsGuesserTest) ... ok
    testSet (__main__.OsGuesserTest) ... ok
    testSetFromMatch (__main__.OsGuesserTest) ... ok

    ----------------------------------------------------------------------
    Ran 6 tests in 1.128s

    OK
    (py27_exscript)[mpenning@tsunami Exscript]$