### PR TITLE
Feature: Protocol TCP SYN timeout (init_timeout)

### DIFF
--- a/src/Exscript/protocols/Dummy.py
+++ b/src/Exscript/protocols/Dummy.py
@@ -72,7 +72,7 @@ class Dummy(Protocol):
     def cancel_expect(self):
         self.cancel = True
 
-    def _connect_hook(self, hostname, port):
+    def _connect_hook(self, hostname, port, init_timeout=None):
         # To more correctly mimic the behavior of a network device, we
         # do not send the banner here, but in authenticate() instead.
         self.buffer.clear()

--- a/src/Exscript/protocols/Protocol.py
+++ b/src/Exscript/protocols/Protocol.py
@@ -205,6 +205,7 @@ class Protocol(object):
                  stdout             = None,
                  stderr             = None,
                  debug              = 0,
+                 init_timeout       = 30,
                  timeout            = 30,
                  logfile            = None,
                  termtype           = 'dumb',
@@ -225,6 +226,7 @@ class Protocol(object):
         @keyword debug: An integer between 0 (no debugging) and 5 (very
             verbose debugging) that specifies the amount of debug info
             sent to the terminal. The default value is 0.
+        @keyword init_timeout: Timeout for the initial TCP connection attempt
         @keyword timeout: See set_timeout(). The default value is 30.
         @keyword logfile: A file into which a log of the conversation with the
             device is dumped.
@@ -253,6 +255,7 @@ class Protocol(object):
         self.verify_fingerprint    = verify_fingerprint
         self.manual_driver         = None
         self.debug                 = debug
+        self.init_timeout          = init_timeout
         self.timeout               = timeout
         self.logfile               = logfile
         self.response              = None
@@ -547,13 +550,13 @@ class Protocol(object):
         """
         return self.timeout
 
-    def _connect_hook(self, host, port):
+    def _connect_hook(self, host, port, init_timeout):
         """
         Should be overwritten.
         """
         raise NotImplementedError()
 
-    def connect(self, hostname = None, port = None):
+    def connect(self, hostname = None, port = None, init_timeout = None):
         """
         Opens the connection to the remote host or IP address.
 
@@ -561,10 +564,12 @@ class Protocol(object):
         @param hostname: The remote host or IP address.
         @type  port: int
         @param port: The remote TCP port number.
+        @type  init_timeout: int
+        @param init_timeout: The initial TCP SYN timeout
         """
         if hostname is not None:
             self.host = hostname
-        return self._connect_hook(self.host, port)
+        return self._connect_hook(self.host, port, self.init_timeout)
 
     def _get_account(self, account):
         if isinstance(account, Context) or isinstance(account, _Context):

--- a/src/Exscript/protocols/Protocol.py
+++ b/src/Exscript/protocols/Protocol.py
@@ -556,7 +556,7 @@ class Protocol(object):
         """
         raise NotImplementedError()
 
-    def connect(self, hostname = None, port = None, init_timeout = None):
+    def connect(self, hostname = None, port = None):
         """
         Opens the connection to the remote host or IP address.
 

--- a/src/Exscript/protocols/Protocol.py
+++ b/src/Exscript/protocols/Protocol.py
@@ -205,7 +205,7 @@ class Protocol(object):
                  stdout             = None,
                  stderr             = None,
                  debug              = 0,
-                 init_timeout       = 30,
+                 connect_timeout    = 30,
                  timeout            = 30,
                  logfile            = None,
                  termtype           = 'dumb',
@@ -226,7 +226,7 @@ class Protocol(object):
         @keyword debug: An integer between 0 (no debugging) and 5 (very
             verbose debugging) that specifies the amount of debug info
             sent to the terminal. The default value is 0.
-        @keyword init_timeout: Timeout for the initial TCP connection attempt
+        @keyword connect_timeout: Timeout for the initial TCP connection attempt
         @keyword timeout: See set_timeout(). The default value is 30.
         @keyword logfile: A file into which a log of the conversation with the
             device is dumped.
@@ -255,7 +255,7 @@ class Protocol(object):
         self.verify_fingerprint    = verify_fingerprint
         self.manual_driver         = None
         self.debug                 = debug
-        self.init_timeout          = init_timeout
+        self.connect_timeout       = connect_timeout
         self.timeout               = timeout
         self.logfile               = logfile
         self.response              = None
@@ -531,23 +531,23 @@ class Protocol(object):
             return self.manual_login_error_re
         return self.get_driver().login_error_re
 
-    def set_init_timeout(self, timeout):
+    def set_connect_timeout(self, timeout):
         """
         Defines the maximum time that the adapter waits for initial connection.
 
         @type  timeout: int
         @param timeout: The maximum time in seconds.
         """
-        self.init_timeout = int(timeout)
+        self.connect_timeout = int(timeout)
 
-    def get_init_timeout(self):
+    def get_connect_timeout(self):
         """
-        Returns the current init_timeout in seconds.
+        Returns the current connect_timeout in seconds.
 
         @rtype:  int
-        @return: The init_timeout in seconds.
+        @return: The connect_timeout in seconds.
         """
-        return self.init_timeout
+        return self.connect_timeout
 
     def set_timeout(self, timeout):
         """

--- a/src/Exscript/protocols/SSH2.py
+++ b/src/Exscript/protocols/SSH2.py
@@ -143,7 +143,7 @@ class SSH2(Protocol):
         # Open a socket.
         sock = socket.socket(af, socket.SOCK_STREAM)
         try:
-            sock.settimeout(self.timeout or None)
+            sock.settimeout(self.init_timeout or None)
         except:
             pass
         sock.connect(addr)
@@ -255,7 +255,7 @@ class SSH2(Protocol):
             self._dbg(1, 'Failed to open shell.')
             raise LoginFailure('Failed to open shell: ' + str(e))
 
-    def _connect_hook(self, hostname, port):
+    def _connect_hook(self, hostname, port, init_timeout):
         self.host   = hostname
         self.port   = port or 22
         self.client = self._paramiko_connect()

--- a/src/Exscript/protocols/SSH2.py
+++ b/src/Exscript/protocols/SSH2.py
@@ -143,7 +143,7 @@ class SSH2(Protocol):
         # Open a socket.
         sock = socket.socket(af, socket.SOCK_STREAM)
         try:
-            sock.settimeout(self.init_timeout or None)
+            sock.settimeout(self.connect_timeout or None)
         except:
             pass
         sock.connect(addr)

--- a/src/Exscript/protocols/Telnet.py
+++ b/src/Exscript/protocols/Telnet.py
@@ -41,7 +41,7 @@ class Telnet(Protocol):
         rows, cols = get_terminal_size()
         self.tn = telnetlib.Telnet(hostname,
                                    port or 23,
-                                   init_timeout     = self.init_timeout,
+                                   connect_timeout     = self.connect_timeout,
                                    termsize         = (rows, cols),
                                    termtype         = self.termtype,
                                    stderr           = self.stderr,

--- a/src/Exscript/protocols/Telnet.py
+++ b/src/Exscript/protocols/Telnet.py
@@ -36,11 +36,12 @@ class Telnet(Protocol):
         self._receive_cb(data)
         self.buffer.append(data)
 
-    def _connect_hook(self, hostname, port):
+    def _connect_hook(self, hostname, port, init_timeout):
         assert self.tn is None
         rows, cols = get_terminal_size()
         self.tn = telnetlib.Telnet(hostname,
                                    port or 23,
+                                   init_timeout     = init_timeout,
                                    termsize         = (rows, cols),
                                    termtype         = self.termtype,
                                    stderr           = self.stderr,

--- a/src/Exscript/protocols/telnetlib.py
+++ b/src/Exscript/protocols/telnetlib.py
@@ -182,6 +182,7 @@ class Telnet:
         self.irawq = 0
         self.cookedq = StringIO()
         self.eof = 0
+        self.init_timetout        = kwargs.get('init_timeout',     None)
         self.window_size          = kwargs.get('termsize')
         self.stdout               = kwargs.get('stdout',           sys.stdout)
         self.stderr               = kwargs.get('stderr',           sys.stderr)
@@ -210,6 +211,7 @@ class Telnet:
             af, socktype, proto, canonname, sa = res
             try:
                 self.sock = socket.socket(af, socktype, proto)
+                self.sock.settimeout(self.init_timetout)
                 self.sock.connect(sa)
             except socket.error, msg:
                 if self.sock:

--- a/src/Exscript/protocols/telnetlib.py
+++ b/src/Exscript/protocols/telnetlib.py
@@ -182,7 +182,7 @@ class Telnet:
         self.irawq = 0
         self.cookedq = StringIO()
         self.eof = 0
-        self.init_timetout        = kwargs.get('init_timeout',     None)
+        self.connect_timeout      = kwargs.get('connect_timeout',     None)
         self.window_size          = kwargs.get('termsize')
         self.stdout               = kwargs.get('stdout',           sys.stdout)
         self.stderr               = kwargs.get('stderr',           sys.stderr)

--- a/tests/Exscript/protocols/ProtocolTest.py
+++ b/tests/Exscript/protocols/ProtocolTest.py
@@ -210,13 +210,13 @@ class ProtocolTest(unittest.TestCase):
     def testGetLoginErrorPrompt(self):
         pass # Already tested in testSetLoginErrorPrompt()
 
-    def testSetInitTimeout(self):
-        self.assert_(self.protocol.get_init_timeout() == 30)
-        self.protocol.set_init_timeout(60)
-        self.assert_(self.protocol.get_init_timeout() == 60)
+    def testSetConnectTimeout(self):
+        self.assert_(self.protocol.get_connect_timeout() == 30)
+        self.protocol.set_connect_timeout(60)
+        self.assert_(self.protocol.get_connect_timeout() == 60)
 
-    def testGetInitTimeout(self):
-        pass # Already tested in testSetTimeout()
+    def testGetConnectTimeout(self):
+        pass # Already tested in testSetConnectTimeout()
 
     def testSetTimeout(self):
         self.assert_(self.protocol.get_timeout() == 30)


### PR DESCRIPTION
## 1. Problem statement

Legacy Exscript TCP timeout behavior is rather annoying... as of Exscript 2.1.440 there is no good way to control how long Exscript waits while trying to connect; by default it's at least 30 seconds (tested on Debian linux 7.1, kernel 3.2.0-4-amd64, Python 2.7.3, Exscript 2.1.440)...

    >>> from Exscript.protocols import SSH2
    >>> conn = SSH2() 
    >>> conn.connect('192.0.2.45')   # 192.0.2.45 doesn't exist

    ## Now wait 30 seconds...

    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "Exscript/protocols/Protocol.py", line 572, in connect
        return self._connect_hook(self.host, port, self.init_timeout)
      File "Exscript/protocols/Telnet.py", line 48, in _connect_hook
        receive_callback = self._telnetlib_received)
      File "Exscript/protocols/telnetlib.py", line 193, in __init__
        self.open(host, port)
      File "Exscript/protocols/telnetlib.py", line 223, in open
        raise socket.error, msg
    socket.timeout: timed out

We need a way to specify a socket-level TCP SYN timeout.  I created the ``init_timeout`` keyword in ``Exscript.protocols.Telnet`` and ``Exscript.protocols.SSH2``,  since ``Exscript.protocols.Protocol.timeout`` is already used...

## 2. Example SSH2 usage with the new ``init_timeout`` keyword:

    >>> from Exscript.protocols import SSH2
    >>> conn = SSH2(init_timeout=3)
    >>> conn.connect('192.0.2.45')   # 192.0.2.45 doesn't exist

    ## Now we only have to wait 3 seconds for ``socket.timeout``

## 3. Example SSH2 usage with the new ``init_timeout`` keyword:

    >>> from Exscript.protocols import Telnet
    >>> conn = Telnet(init_timeout=3)
    >>> conn.connect('192.0.2.45')   # 192.0.2.45 doesn't exist

    ## Now we only have to wait 3 seconds for ``socket.timeout``

## 4. ``make tests`` for this PR
    .............................................................................................................................................................................    ...............................................................................................................
    ----------------------------------------------------------------------
    Ran 500 tests in 198.295s

    OK
