### PR TITLE
Add cisco ace driver

### DIFF
--- a/src/Exscript/protocols/drivers/__init__.py
+++ b/src/Exscript/protocols/drivers/__init__.py
@@ -10,6 +10,7 @@ from Exscript.protocols.drivers.hp_pro_curve import HPProCurveDriver
 from Exscript.protocols.drivers.ios import IOSDriver
 from Exscript.protocols.drivers.nxos import NXOSDriver
 from Exscript.protocols.drivers.ios_xr import IOSXRDriver
+from Exscript.protocols.drivers.ace import ACEDriver
 from Exscript.protocols.drivers.junos import JunOSDriver
 from Exscript.protocols.drivers.junos_erx import JunOSERXDriver
 from Exscript.protocols.drivers.one_os import OneOSDriver

--- a/src/Exscript/protocols/drivers/ace.py
+++ b/src/Exscript/protocols/drivers/ace.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2007-2010 Samuel Abels.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+"""
+A driver for Cisco Application Control Engine (ACE)
+"""
+import re
+from Exscript.protocols.drivers.driver import Driver
+
+_user_re     = [re.compile(r'user ?name: ?$', re.I)]
+_password_re = [re.compile(r'(?:[\r\n]Password: ?|last resort password:)$')]
+_tacacs_re   = re.compile(r'[\r\n]s\/key[\S ]+\r?%s' % _password_re[0].pattern)
+_prompt_re   = [re.compile(r'[\r\n][\-\w+\.:/]+(?:\([^\)]+\))?[>#] ?$')]
+_error_re    = [re.compile(r'%Error'),
+                re.compile(r'invalid input', re.I),
+                re.compile(r'(?:incomplete|ambiguous) command', re.I),
+                re.compile(r'connection timed out', re.I),
+                re.compile(r'[^\r\n]+ not found', re.I)]
+
+class ACEDriver(Driver):
+    def __init__(self):
+        Driver.__init__(self, 'ace')
+        self.user_re     = _user_re
+        self.password_re = _password_re
+        self.prompt_re   = _prompt_re
+        self.error_re    = _error_re
+
+    def check_head_for_os(self, string):
+        if 'Cisco Application Control Software' in string:
+            return 90
+
+    def init_terminal(self, conn):
+        conn.execute('term len 0')
+
+    def auto_authorize(self, conn, account, flush, bailout):
+        conn.send('enable\r')
+        conn.app_authorize(account, flush, bailout)

--- a/tests/Exscript/protocols/banners/ace.1
+++ b/tests/Exscript/protocols/banners/ace.1
@@ -1,0 +1,11 @@
+(Banner goes here)
+
+Cisco Application Control Software (ACSW)
+TAC support: http://www.cisco.com/tac
+Copyright (c) 1985-2014 by Cisco Systems, Inc. All rights reserved.
+The copyrights to certain works contained herein are owned by
+other third parties and are used and distributed under license.
+Some parts of this software are covered under the GNU Public
+License. A copy of the license is available at
+http://www.gnu.org/licenses/gpl.html.
+hostname/context#


### PR DESCRIPTION
Add a new driver to interact with Cisco Application Control Engine (ACE) that are load balancing module card of Cisco System.

This is basically the same driver as IOSDriver except that we execute different commands for the **autoinit()** method (no *terminal width xx* command)