### PR TITLE
Add new driver for F5 BigIP devices

### DIFF
--- a/src/Exscript/protocols/drivers/__init__.py
+++ b/src/Exscript/protocols/drivers/__init__.py
@@ -20,6 +20,7 @@ from Exscript.protocols.drivers.sros import SROSDriver
 from Exscript.protocols.drivers.aruba import ArubaDriver
 from Exscript.protocols.drivers.enterasys_wc import EnterasysWCDriver
 from Exscript.protocols.drivers.fortios import FortiOSDriver
+from Exscript.protocols.drivers.bigip import BigIPDriver
 
 driver_classes = []
 drivers        = []

--- a/src/Exscript/protocols/drivers/bigip.py
+++ b/src/Exscript/protocols/drivers/bigip.py
@@ -1,0 +1,43 @@
+# Copyright (C) 2007-2010 Samuel Abels.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 2, as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+"""
+A driver for F5 Big-IP system (TMSH SHELL)
+"""
+import re
+from Exscript.protocols.drivers.driver import Driver
+
+_user_re     = [re.compile(r'user ?name: ?$', re.I)]
+_password_re = [re.compile(r'(?:[\r\n]Password: ?|last resort password:)$')]
+_prompt_re   = [re.compile(r'\S+@(\(.*?\)){1,4}\(tmos.*?\)#\s?')]
+_error_re    = [re.compile(r'Syntax Error', re.I),
+                re.compile(r'connection timed out', re.I)]
+
+class BigIPDriver(Driver):
+    def __init__(self):
+        Driver.__init__(self, 'bigip')
+        self.user_re     = _user_re
+        self.password_re = _password_re
+        self.prompt_re   = _prompt_re
+        self.error_re    = _error_re
+
+    def check_head_for_os(self, string):
+        if "(tmos)" in string:
+            return 90
+
+    def init_terminal(self, conn):
+        conn.execute('modify cli preference pager disabled')
+
+    def auto_authorize(self, conn, account, flush, bailout):
+        pass

--- a/tests/Exscript/protocols/banners/bigip.1
+++ b/tests/Exscript/protocols/banners/bigip.1
@@ -1,0 +1,2 @@
+(Banner goes here)
+user@(hostname)(cfg-sync In Sync)(Active)(/Common)(tmos)#


### PR DESCRIPTION
This new driver handles the CLI for F5 BigIP software. The CLI is the TMSH environment only (the advanced sheel is bascially a Linux shell).