### PR TITLE
modified aironet driver to work with WiSM2 controllers

### DIFF
--- a/src/Exscript/protocols/drivers/aironet.py
+++ b/src/Exscript/protocols/drivers/aironet.py
@@ -20,7 +20,7 @@ from Exscript.protocols.drivers.driver import Driver
 
 _user_re     = [re.compile(r'User:\s$', re.I)]
 _password_re = [re.compile(r'(?:[\r\n]Password: ?|last resort password:)$')]
-_prompt_re   = [re.compile(r'[\r\n].(?:(?:Cisco\sController)|(?:WiSM\S+?)).\s>$')]
+_prompt_re   = [re.compile(r'[\r\n].(?:(?:Cisco\sController)|(?:WiSM\S+?)|(?:\(.+\))).\s>$')]
 _error_re    = [re.compile(r'Incorrect\susage', re.I),
                 re.compile(r'Incorrect\sinput', re.I),
                 re.compile(r'connection timed out', re.I),
@@ -36,6 +36,8 @@ class AironetDriver(Driver):
         if '(Cisco Controller)' in string:
             return 90
         elif '(WiSM-slot' in string:
+            return 90
+        elif ') >' in string:
             return 90
         return 0
 

--- a/src/Exscript/protocols/drivers/aironet.py
+++ b/src/Exscript/protocols/drivers/aironet.py
@@ -38,7 +38,7 @@ class AironetDriver(Driver):
         elif '(WiSM-slot' in string:
             return 90
         elif ') >' in string:
-            return 90
+            return 87
         return 0
 
     def init_terminal(self, conn):


### PR DESCRIPTION
I have some WiSM2 wireless controllers and the prompt was not detected without this modification. It does seem like a vague prompt detection, but the prompt is as follows:

(controllername) >

"controllername" is whatever the user-defined hostname is.