### PR TITLE
Handle ASA terminal paging in IOS driver.

### DIFF
--- a/src/Exscript/protocols/drivers/ios.py
+++ b/src/Exscript/protocols/drivers/ios.py
@@ -17,6 +17,8 @@ A driver for Cisco IOS (not IOS XR).
 """
 import re
 from Exscript.protocols.drivers.driver import Driver
+from Exscript.protocols.Exception import InvalidCommandException
+
 
 _user_re     = [re.compile(r'user ?name: ?$', re.I)]
 _password_re = [re.compile(r'(?:[\r\n]Password: ?|last resort password:)$')]
@@ -46,8 +48,13 @@ class IOSDriver(Driver):
         return 0
 
     def init_terminal(self, conn):
-        conn.execute('term len 0')
-        conn.execute('term width 0')
+        # Try the standard term len/width ios commands
+        try:
+            conn.execute('term len 0')
+            conn.execute('term width 0')
+        except InvalidCommandException:
+            # Deal with croner cases liek the Cisco ASA
+            conn.execute('term pager 0')
 
     def auto_authorize(self, conn, account, flush, bailout):
         conn.send('enable\r')

--- a/src/Exscript/protocols/drivers/ios.py
+++ b/src/Exscript/protocols/drivers/ios.py
@@ -53,7 +53,7 @@ class IOSDriver(Driver):
             conn.execute('term len 0')
             conn.execute('term width 0')
         except InvalidCommandException:
-            # Deal with croner cases liek the Cisco ASA
+            # Deal with corner cases like the Cisco ASA
             conn.execute('term pager 0')
 
     def auto_authorize(self, conn, account, flush, bailout):


### PR DESCRIPTION
Added a simple try except to the init_terminal code to handle the differences between the Cisco ASA and IOS.  This is a little hacky, but I don't think it's possible to handle this in the os_guesser currently.
