### PR TITLE
Fix issue with consumer parameter

### DIFF
--- a/src/Exscript/protocols/Protocol.py
+++ b/src/Exscript/protocols/Protocol.py
@@ -920,6 +920,8 @@ class Protocol(object):
         @return: The index of the prompt regular expression that matched,
           and the match object.
         """
+        if not consume:
+            self.buffer.clear()
         self.send(command + '\r')
         return self.expect_prompt(consume)
 

--- a/src/Exscript/protocols/SSH2.py
+++ b/src/Exscript/protocols/SSH2.py
@@ -336,6 +336,7 @@ class SSH2(Protocol):
                 self.response = self.buffer.pop(end)
                 self.buffer.pop(match.end()-match.start())
             else:
+                end = self.buffer.size()  # Capture the whole buffer if we do not flush (prompt included)
                 self.response = self.buffer.head(end)
             return n, match
 


### PR DESCRIPTION
After this fix we are able to correctly use the **consume** parameter in the *Protocol.execute()* method.