### PR TITLE
Add a new driver for Ciena SAOS Devices

### DIFF
--- a/Exscript/protocols/drivers/__init__.py
+++ b/Exscript/protocols/drivers/__init__.py
@@ -51,6 +51,7 @@ from Exscript.protocols.drivers.vxworks import VxworksDriver
 from Exscript.protocols.drivers.ericsson_ban import EricssonBanDriver
 from Exscript.protocols.drivers.rios import RIOSDriver
 from Exscript.protocols.drivers.eos import EOSDriver
+from Exscript.protocols.drivers.cienasaos import CienaSAOSDriver
 
 driver_classes = []
 drivers = []

--- a/Exscript/protocols/drivers/cienasaos.py
+++ b/Exscript/protocols/drivers/cienasaos.py
@@ -1,0 +1,32 @@
+"""
+A driver for Ciena SAOS carrier ethernet devices
+"""
+import re
+from Exscript.protocols.drivers.driver import Driver
+
+_user_re = [re.compile(r'[^:]* login: ?$', re.I)]
+_password_re = [re.compile(r'Password: ?$')]
+_prompt_re = [re.compile(r'[\r\n][\-\w+\.:/]+[>#] ?$')]
+_error_re = [re.compile(r'SHELL PARSER FAILURE'),
+             re.compile(r'invalid input', re.I),
+             re.compile(r'(?:incomplete|ambiguous) command', re.I),
+             re.compile(r'connection timed out', re.I),
+             re.compile(r'[^\r\n]+ not found', re.I)]
+
+
+class CienaSAOSDriver(Driver):
+
+    def __init__(self):
+        Driver.__init__(self, 'cienasaos')
+        self.user_re = _user_re
+        self.password_re = _password_re
+        self.prompt_re = _prompt_re
+        self.error_re = _error_re
+
+    def check_head_for_os(self, string):
+        if 'SAOS is True Carrier Ethernet TM software' in string:
+            return 90
+        return 0
+
+    def init_terminal(self, conn):
+        conn.execute('system shell session set more off')

--- a/tests/Exscript/protocols/banners/cienasaos.1
+++ b/tests/Exscript/protocols/banners/cienasaos.1
@@ -1,0 +1,12 @@
+
+(Banner goes here)
+SAOS is True Carrier Ethernet TM software.
+
+testhost login: testuser
+Password:
+
+
+SAOS is True Carrier Ethernet TM software.
+Welcome to the shell.
+testhost>
+


### PR DESCRIPTION
Add a new driver to manage Ciena SAOS devices (previously Worldwide Packets)

Example login:

telnet 10.8.91.1
Trying 10.8.91.1...
Connected to 10.8.91.1 (10.8.91.1).
Escape character is '^]'.

LAB_00009-SAS51-100 9c:7a:03:c8:60:40
SAOS is True Carrier Ethernet TM software.

LAB_00009-SAS51-100 login: m-wallraf
Password:


SAOS is True Carrier Ethernet TM software.
Welcome to the shell.
LAB_00009-SAS51-100>
LAB_00009-SAS51-100> system show

+------------------------------ HOST NAME -------------------------------+
| Oper | LAB_00009-SAS51-100                                             |
| User | LAB_00009-SAS51-100                                             |
| DHCP |                                                                 |
+------+-----------------------------------------------------------------+
