### PR TITLE
SSH reconnection is now handle at Driver level

### DIFF
--- a/Exscript/protocols/drivers/driver.py
+++ b/Exscript/protocols/drivers/driver.py
@@ -87,6 +87,7 @@ class Driver(object):
         self.prompt_re = _prompt_re
         self.error_re = _error_re
         self.login_error_re = _login_fail_re
+        self.reconnect_between_auth_methods = False
 
     def check_protocol_for_os(self, string):
         return 0

--- a/Exscript/protocols/drivers/junos_erx.py
+++ b/Exscript/protocols/drivers/junos_erx.py
@@ -39,6 +39,10 @@ class JunOSERXDriver(Driver):
         self.user_re = _user_re
         self.password_re = _password_re
         self.prompt_re = _prompt_re
+        # JunOS ERX OS do not accept further login
+        # attempts after failing one. So in this hack, we
+        # re-connect after each attempt...
+        self.reconnect_between_auth_methods = True
 
     def check_head_for_os(self, string):
         if _junos_re.search(string):

--- a/Exscript/protocols/ssh2.py
+++ b/Exscript/protocols/ssh2.py
@@ -58,8 +58,6 @@ auth_types = {'publickey': ('_paramiko_auth_agent', '_paramiko_auth_autokey'),
               'keyboard-interactive': ('_paramiko_auth_interactive',),
               'password': ('_paramiko_auth_password',)}
 
-# See below for what this does.
-_authentication_reconnect_hack = True
 
 class SSH2(Protocol):
 
@@ -293,7 +291,7 @@ class SSH2(Protocol):
             # Some OSes (e.g. JunOS ERX OS) do not accept further login
             # attempts after failing one. So in this hack, we
             # re-connect after each attempt...
-            if _authentication_reconnect_hack:
+            if self.get_driver().reconnect_between_auth_methods:
                 self.close(force=True)
                 self.client = self._paramiko_connect()
 


### PR DESCRIPTION
Pull request regarding issue #166 .

Still need to fix Junos ERX driver guessing at protocol level, waiting for someone who has access to such device in production.