### PR TITLE
Fix UnboundLocalError: local variable 'msg' referenced before assignment

### DIFF
--- a/Exscript/protocols/telnetlib.py
+++ b/Exscript/protocols/telnetlib.py
@@ -246,7 +246,8 @@ class Telnet(object):
                 self.sock = socket.socket(af, socktype, proto)
                 self.sock.settimeout(self.connect_timeout)
                 self.sock.connect(sa)
-            except socket.error as msg:
+            except socket.error as msg_:
+                msg = '{} => telnet://{}:{}'.format(msg_, host, port)
                 if self.sock:
                     self.sock.close()
                 self.sock = None


### PR DESCRIPTION
Occurred error when connection refused. Detected on python3.6
```
  File "/home/ogrynch/proj/confmon/mon.py", line 58, in connect
    self._conn.connect(hostname=self._exscript_host.get_address(), port=int(self._exscript_host.get_tcp_port()))
  File "/home/ogrynch/.local/share/virtualenvs/confmon-Ga4T0tkI/lib/python3.6/site-packages/Exscript/protocols/protocol.py", line 631, in connect
    conn = self._connect_hook(self.host, port)
  File "/home/ogrynch/.local/share/virtualenvs/confmon-Ga4T0tkI/lib/python3.6/site-packages/Exscript/protocols/telnet.py", line 60, in _connect_hook
    receive_callback=self._telnetlib_received)
  File "/home/ogrynch/.local/share/virtualenvs/confmon-Ga4T0tkI/lib/python3.6/site-packages/Exscript/protocols/telnetlib.py", line 226, in __init__
    self.open(host, port)
  File "/home/ogrynch/.local/share/virtualenvs/confmon-Ga4T0tkI/lib/python3.6/site-packages/Exscript/protocols/telnetlib.py", line 256, in open
    raise socket.error(msg)
UnboundLocalError: local variable 'msg' referenced before assignment

Process finished with exit code 1

```