### PR TITLE
Correct handling user prompt on Cisco Nexus OS (NXOS)

### DIFF
--- a/Exscript/protocols/drivers/nxos.py
+++ b/Exscript/protocols/drivers/nxos.py
@@ -26,7 +26,7 @@ A driver for Cisco Nexus OS (NXOS)
 import re
 from Exscript.protocols.drivers.driver import Driver
 
-_user_re = [re.compile(r'user ?name: ?$', re.I)]
+_user_re = [re.compile(r'user ?name: ?$', re.I), re.compile(r'[^:]* login: ?$', re.I)]
 _password_re = [re.compile(r'(?:[\r\n]Password: ?|last resort password:)$')]
 _prompt_re = [re.compile(r'[\r\n][\-\w+\.:/]+(?:\([^\)]+\))?[>#] ?$')]
 _error_re = [re.compile(r'%Error'),


### PR DESCRIPTION
Example telnet connection with login prompt
```
username@home ~ % telnet X.X.X.X
Trying X.X.X.X...
Connected to X.X.X.X.
Escape character is '^]'.

User Access Verification
RackX_XXX login: admin
Password: 
Bad terminal type: "linux". Will assume vt100.
Cisco Nexus Operating System (NX-OS) Software
TAC support: http://www.cisco.com/tac
Copyright (C) 2002-2015, Cisco and/or its affiliates.
All rights reserved.
The copyrights to certain works contained in this software are
owned by other third parties and used and distributed under their own
licenses, such as open source.  This software is provided "as is," and unless
otherwise stated, there is no warranty, express or implied, including but not
limited to warranties of merchantability and fitness for a particular purpose.
Certain components of this software are licensed under
the GNU General Public License (GPL) version 2.0 or 
GNU General Public License (GPL) version 3.0  or the GNU
Lesser General Public License (LGPL) Version 2.1 or 
Lesser General Public License (LGPL) Version 2.0. 
A copy of each such license is available at
http://www.opensource.org/licenses/gpl-2.0.php and
http://opensource.org/licenses/gpl-3.0.html and
http://www.opensource.org/licenses/lgpl-2.1.php and
http://www.gnu.org/licenses/old-licenses/library.txt.
RackX_XXX#
```