### PR TITLE
Updated PrivateKey.from_file to handle encrypted keys

### DIFF
--- a/Exscript/key.py
+++ b/Exscript/key.py
@@ -68,13 +68,13 @@ class PrivateKey(object):
         """
         if keytype is None:
             try:
-                key = RSAKey.from_private_key_file(filename)
+                RSAKey.from_private_key_file(filename, password=password)
                 keytype = 'rsa'
-            except SSHException as e:
+            except SSHException:
                 try:
-                    key = DSSKey.from_private_key_file(filename)
+                    DSSKey.from_private_key_file(filename, password=password)
                     keytype = 'dss'
-                except SSHException as e:
+                except SSHException:
                     msg = 'not a recognized private key: ' + repr(filename)
                     raise ValueError(msg)
         key = PrivateKey(keytype)

--- a/tests/Exscript/PrivateKeyTest.py
+++ b/tests/Exscript/PrivateKeyTest.py
@@ -1,7 +1,7 @@
+import os.path
 import sys
 import unittest
-import re
-import os.path
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
 
 from Exscript import PrivateKey
@@ -54,5 +54,7 @@ class PrivateKeyTest(unittest.TestCase):
 
 def suite():
     return unittest.TestLoader().loadTestsFromTestCase(PrivateKeyTest)
+
+
 if __name__ == '__main__':
     unittest.TextTestRunner(verbosity=2).run(suite())


### PR DESCRIPTION
The decryption password is now passed to the underlying key class when attempting to determine the key type. This ensures PasswordRequiredException is not raised during this process.