### PR TITLE
include terminal width for Ekinops one_os driver

### DIFF
--- a/Exscript/protocols/drivers/one_os.py
+++ b/Exscript/protocols/drivers/one_os.py
@@ -47,6 +47,12 @@ class OneOSDriver(Driver):
 
     def init_terminal(self, conn):
         conn.execute('term len 0')
+        # TERMINAL WIDTH ONEOS5
+        try:
+            conn.execute('stty columns 255')
+        except:
+            pass
+        
 
     def auto_authorize(self, conn, account, flush, bailout):
         conn.send('enable\r')

--- a/Exscript/protocols/drivers/one_os.py
+++ b/Exscript/protocols/drivers/one_os.py
@@ -50,9 +50,8 @@ class OneOSDriver(Driver):
         # TERMINAL WIDTH ONEOS5
         try:
             conn.execute('stty columns 255')
-        except:
+        except Exception:
             pass
-        
 
     def auto_authorize(self, conn, account, flush, bailout):
         conn.send('enable\r')


### PR DESCRIPTION
without terminal width it produces ugly output on ONEOS v5