### PR TITLE
docs: Fix a few typos

### DIFF
--- a/Exscript/emulators/command.py
+++ b/Exscript/emulators/command.py
@@ -65,7 +65,7 @@ class CommandSet(object):
         :type  command: str|regex
         :param command: A string or a compiled regular expression.
         :type  response: function|str
-        :param response: A reponse, or a response handler.
+        :param response: A response, or a response handler.
         """
         command = re.compile(command)
         self.response_list.append((command, response))

--- a/Exscript/interpreter/regex.py
+++ b/Exscript/interpreter/regex.py
@@ -24,7 +24,7 @@ from __future__ import print_function, absolute_import
 import re
 from .string import String
 
-# Matches any opening parenthesis that is neither preceeded by a backslash
+# Matches any opening parenthesis that is neither preceded by a backslash
 # nor has a "?:" or "?<" appended.
 bracket_re = re.compile(r'(?<!\\)\((?!\?[:<])', re.I)
 

--- a/Exscript/interpreter/template.py
+++ b/Exscript/interpreter/template.py
@@ -67,7 +67,7 @@ class Template(Scope):
             elif lexer.current_is('escaped_data'):
                 token = lexer.token()[1]
                 if token[1] == '$':
-                    # An escaped $ is handeled by the Execute() token, so
+                    # An escaped $ is handled by the Execute() token, so
                     # we do not strip the \ here.
                     buffer += token
                 else:

--- a/Exscript/key.py
+++ b/Exscript/key.py
@@ -32,7 +32,7 @@ class PrivateKey(object):
 
     """
     Represents a cryptographic key, and may be used to authenticate
-    useing :class:`Exscript.protocols`.
+    using :class:`Exscript.protocols`.
     """
     keytypes = set()
 

--- a/Exscript/util/mail.py
+++ b/Exscript/util/mail.py
@@ -101,10 +101,10 @@ def _get_var_from_header_line(line):
     return match.group(1).strip().lower(), match.group(2).strip()
 
 
-def _cleanup_mail_addresses(receipients):
-    if isinstance(receipients, list):
-        receipients = ','.join(receipients)
-    rcpt = re.split(r'\s*[,;\r\n]\s*', receipients.lower())
+def _cleanup_mail_addresses(recipients):
+    if isinstance(recipients, list):
+        recipients = ','.join(recipients)
+    rcpt = re.split(r'\s*[,;\r\n]\s*', recipients.lower())
     return [str(r) for r in sorted(set(rcpt)) if r.strip()]
 
 #
@@ -215,7 +215,7 @@ class Mail(object):
 
     def set_to(self, to):
         """
-        Replaces the current list of receipients in the 'to' field by
+        Replaces the current list of recipients in the 'to' field by
         the given value. The value may be one of the following:
 
           - A list of strings (email addresses).
@@ -229,7 +229,7 @@ class Mail(object):
 
     def add_to(self, to):
         """
-        Adds the given list of receipients to the 'to' field.
+        Adds the given list of recipients to the 'to' field.
         Accepts the same argument types as set_to().
 
         :type  to: string|list(string)
@@ -305,12 +305,12 @@ class Mail(object):
         """
         return self.bcc
 
-    def get_receipients(self):
+    def get_recipients(self):
         """
-        Returns a list of all receipients (to, cc, and bcc).
+        Returns a list of all recipients (to, cc, and bcc).
 
         :rtype:  list(string)
-        :return: The email addresses of all receipients.
+        :return: The email addresses of all recipients.
         """
         return self.get_to() + self.get_cc() + self.get_bcc()
 
@@ -469,7 +469,7 @@ def send(mail, server='localhost'):
     :param server: The address of the mailserver.
     """
     sender = mail.get_sender()
-    rcpt = mail.get_receipients()
+    rcpt = mail.get_recipients()
     session = smtplib.SMTP(server)
     message = MIMEMultipart()
     message['Subject'] = mail.get_subject()

--- a/Exscript/util/tty.py
+++ b/Exscript/util/tty.py
@@ -65,21 +65,21 @@ def get_terminal_size(default_rows=25, default_cols=80):
         # Channel was redirected to an object that has no fileno()
         pass
     except ValueError:
-        # Channel was closed while attemting to read it
+        # Channel was closed while attempting to read it
         pass
     try:
         fileno_list.append(sys.stdin.fileno())
     except AttributeError:
         pass
     except ValueError:
-        # Channel was closed while attemting to read it
+        # Channel was closed while attempting to read it
         pass
     try:
         fileno_list.append(sys.stderr.fileno())
     except AttributeError:
         pass
     except ValueError:
-        # Channel was closed while attemting to read it
+        # Channel was closed while attempting to read it
         pass
 
     # Ask each channel for the terminal window size.

--- a/Exscript/util/url.py
+++ b/Exscript/util/url.py
@@ -182,7 +182,7 @@ class Url(object):
         :type  default_protocol: string
         :param default_protocol: A protocol name.
         :rtype:  Url
-        :return: The Url object contructed from the given URL.
+        :return: The Url object constructed from the given URL.
         """
         if url is None:
             raise TypeError('Expected string but got' + type(url))


### PR DESCRIPTION
There are small typos in:
- Exscript/emulators/command.py
- Exscript/interpreter/regex.py
- Exscript/interpreter/template.py
- Exscript/key.py
- Exscript/util/mail.py
- Exscript/util/tty.py
- Exscript/util/url.py

Fixes:
- Should read `recipients` rather than `receipients`.
- Should read `attempting` rather than `attemting`.
- Should read `using` rather than `useing`.
- Should read `response` rather than `reponse`.
- Should read `preceded` rather than `preceeded`.
- Should read `handled` rather than `handeled`.
- Should read `constructed` rather than `contructed`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md