### PR TITLE
Fixes issue #191

### DIFF
--- a/Exscript/protocols/telnetlib.py
+++ b/Exscript/protocols/telnetlib.py
@@ -573,7 +573,7 @@ class Telnet(object):
         # headaches for Py2/Py3 compatibility...
         c = self.rawq[self.irawq]
         if not py2:
-            c = c.to_bytes((c.bit_length()+7)//8, 'big')
+            c = c.to_bytes((c.bit_length()+7)//8 or 1, 'big')
 
         self.irawq += 1
         if self.irawq >= len(self.rawq):


### PR DESCRIPTION
If `c` is zero, then `c.bit_length()` is zero too.
So `c.to_bytes((c.bit_length()+7)//8, 'big')` will return empty string, which is not correct. We need '\x00'.